### PR TITLE
No longer need url parms for getting a counter

### DIFF
--- a/server/src/main/java/com/example/Counters.java
+++ b/server/src/main/java/com/example/Counters.java
@@ -15,7 +15,7 @@ public class Counters {
     /**
      * Loads persistent data into the container
      */
-    public static void loadPersistantData() {
+    public static void loadPersistentData() {
         // can load from a db or any other source here
         counters.put("visits", new CounterBean("visits", 0));
     }

--- a/server/src/main/java/com/example/CountersApi.java
+++ b/server/src/main/java/com/example/CountersApi.java
@@ -82,10 +82,10 @@ public class CountersApi {
     }
 
 
-    @Path("/get")
+    @Path("/get/{key}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getCounter(@QueryParam("key") String key) {
+    public String getCounter(@PathParam("key") String key) {
         GsonBuilder builder = new GsonBuilder();
         Gson gson = builder.create();
         return gson.toJson(Counters.get(key));

--- a/server/src/main/java/com/example/Main.java
+++ b/server/src/main/java/com/example/Main.java
@@ -21,12 +21,10 @@ public class Main {
      * @return Grizzly HTTP server.
      */
     public static HttpServer startServer() {
-        // create a resource config that scans for JAX-RS resources and providers
-        // in com.example package
+        // create a resource config that scans for JAX-RS resources and providers in com.example package
         final ResourceConfig rc = new ResourceConfig().packages("com.example");
 
-        // create and start a new instance of grizzly http server
-        // exposing the Jersey application at BASE_URI
+        // create and start a new instance of grizzly http server exposing the Jersey application at BASE_URI
         return GrizzlyHttpServerFactory.createHttpServer(URI.create(BASE_URI), rc);
     }
 
@@ -37,13 +35,25 @@ public class Main {
      * @throws IOException
      */
     public static void main(String[] args) throws IOException {
-        Counters.loadPersistantData();
+
+        System.out.println("[INFO] Loading Persistant Data...");
+        Counters.loadPersistentData();
+        System.out.println("[INFO] Persistent Data loaded.");
+
+        System.out.println("[INFO] Creating Grizzly Server...");
         final HttpServer server = startServer();
-        System.out.println(String.format("Jersey app started with WADL available at "
-                + "%sapplication.wadl\nHit enter to stop it...", BASE_URI));
+        System.out.println("[INFO] Created Grizzly Server.");
+        System.out.println("[INFO] Server is " + (server.isStarted() ? "" : "not ") + "running.");
+
+        System.out.println(String.format("[INFO] Jersey app started with WADL available at " + "%sapplication.wadl", BASE_URI));
+        System.out.println("[INFO] Hit enter to stop it...");
+
         System.in.read();
         server.stop();
+
+        System.out.println("[INFO] Saving Persistent Data...");
         Counters.savePersistentData();
+        System.out.println("[INFO] Persistent Data Saved.");
     }
 }
 

--- a/server/src/test/java/com/example/CountersApiTest.java
+++ b/server/src/test/java/com/example/CountersApiTest.java
@@ -2,14 +2,11 @@ package com.example;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -19,7 +16,6 @@ import javax.ws.rs.core.Response;
 
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -55,7 +51,7 @@ public class CountersApiTest {
     @Test
     public void shouldIncreaseCounters() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
         Response responseMsg = target.path("counters/increase").request().header("key", "visits").post(Entity.text("POST"));
         String ent = responseMsg.readEntity(String.class);
         assertEquals("1", ent);
@@ -101,7 +97,7 @@ public class CountersApiTest {
     @Test
     public void shouldNotAddAlreadyExistingName() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
 
         // when
         Response responseMsg = target.path("counters/add").request().header("key", "visits").post(Entity.text("POST"));
@@ -144,7 +140,7 @@ public class CountersApiTest {
     @Test
     public void shouldReturnAllCounters() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
 
         // add a new counter
         Response response = target.path("counters/add").request().header("key", "counterc").post(Entity.text("Code:200"));
@@ -174,7 +170,7 @@ public class CountersApiTest {
     @Test
     public void shouldReturnSpecificCounter() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
 
         // when
         String resp = target.path("counters/get").queryParam("key", "visits").request().get(String.class);
@@ -194,7 +190,7 @@ public class CountersApiTest {
     @Test
     public void shouldReturnNullOnGettingCounter() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
 
         // when
         String resp = target.path("counters/get").queryParam("key", "invalidname").request().get(String.class);
@@ -207,7 +203,7 @@ public class CountersApiTest {
     @Test
     public void shouldReturn404StatusCode() {
         // given
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
         expectedException.expect(NotFoundException.class);
         expectedException.expectMessage("HTTP 404 Not Found");
 
@@ -221,7 +217,7 @@ public class CountersApiTest {
     @Ignore
     @Test
     public void singleThreadStressTest() {
-        Counters.loadPersistantData();
+        Counters.loadPersistentData();
         int iterations = 100000;
 
         long start = System.currentTimeMillis();


### PR DESCRIPTION
Updated to no longer need ?key=value in the GET call for a counter. You
now just pass in the key as part of the url: /counters/get/countername
